### PR TITLE
Async and non-async methods are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ export class Tests {
         throw new Error("There was an error processing this test. Try again");
     }
 
+    // Will be executed asynchronously as Deno supports the keyword `async` for testing.
     @Test({
         name: "Should pass"
     })
-    public mytest2() {
+    public async mytest2() {
         return true;
     }
 }

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
     "name": "Orange",
     "description": "A decorator-driven testing library for Deno & mandarine-powered applications",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "entry": "./mod.ts",
     "stable": true,
     "unlisted": false,

--- a/lib/decorators/testDecorator.ts
+++ b/lib/decorators/testDecorator.ts
@@ -1,6 +1,7 @@
 import { yellow } from "https://deno.land/std/fmt/colors.ts";
 import { Orange } from "../core.ns.ts";
-import { TestProxy } from "../proxy/testProxy.ts";
+import { TestProxyAsync, TestProxySync } from "../proxy/testProxy.ts";
+
 
 export const Test = (options: Orange.TestOptions) => {
     return (target: any, propertyKey: string) => {
@@ -16,6 +17,10 @@ export const Test = (options: Orange.TestOptions) => {
         let testMethod = Orange.Core.getTestSuite(target)[propertyKey];
         let testSuiteConfig = Orange.Core.getTestSuiteConfig(target);
 
+        let beforeAllHook: Function = testSuiteConfig.hooks?.beforeAll;
+        let beforeEachHook: Function = testSuiteConfig.hooks?.beforeEach;
+        let afterEachHook: Function = testSuiteConfig.hooks?.afterEach;
+
         let ignore = options.ignore || testSuiteConfig.ignore; 
         if(ignore)  {
             Orange.Core.updateTestSuiteStats(target, "NumTestsIgnored");
@@ -23,22 +28,33 @@ export const Test = (options: Orange.TestOptions) => {
         }
 
         let testSuiteStats = Orange.Core.getTestSuiteStats(target);
-        
-        Deno.test({
-            name: testName,
-            ignore: ignore,
-            fn: async () => {
-                let beforeAllHook: Function = testSuiteConfig.hooks?.beforeAll;
-                let beforeEachHook: Function = testSuiteConfig.hooks?.beforeEach;
-                let afterEachHook: Function = testSuiteConfig.hooks?.afterEach;
+        let testFunction: () => void | Promise<void>;
 
+        if(testMethod instanceof Orange.AsyncFunction) {
+            console.log("It's async");
+            testFunction = async () => {
                 if(testSuiteStats.numberOfTestsRan == 0 && beforeAllHook) beforeAllHook();
                 if(beforeEachHook) beforeEachHook();
 
-                (await TestProxy(testMethod, target, testSuiteConfig, options, propertyKey))();
+                (await TestProxyAsync(testMethod, target, testSuiteConfig, options, propertyKey))();
+
+                if(afterEachHook && !Orange.Core.isLastTest(testSuiteStats.numberOfTests, testSuiteStats.numberOfTestsIgnored, testSuiteStats.numberOfTestsRan)) afterEachHook();
+            };
+        } else {
+            testFunction = () => {
+                if(testSuiteStats.numberOfTestsRan == 0 && beforeAllHook) beforeAllHook();
+                if(beforeEachHook) beforeEachHook();
+
+                TestProxySync(testMethod, target, testSuiteConfig, options, propertyKey)();
 
                 if(afterEachHook && !Orange.Core.isLastTest(testSuiteStats.numberOfTests, testSuiteStats.numberOfTestsIgnored, testSuiteStats.numberOfTestsRan)) afterEachHook();
             }
-        });
+        }
+
+        Deno.test({
+            name: testName,
+            ignore: ignore,
+            fn: testFunction
+        })
     }
 }

--- a/quick-examples/quickexample_test.ts
+++ b/quick-examples/quickexample_test.ts
@@ -42,7 +42,7 @@ export class StringTests {
     @Test({
         description: "Elon Musk is Jeff bezos",
     })
-    public elonIsNotJeffBezos() {
+    public async elonIsNotJeffBezos() {
         assert.assertEquals("Elon Musk", "Jeff Bezos");
     }
 


### PR DESCRIPTION
Async and non-async methods are supported for testing. Before, every test was executed asynchronously inside the Deno testing API. now it is possible to define this behavior: If your method to be tested has the keyword `async`, Orange will recognize it.